### PR TITLE
Browser session carrying for dependent testcases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ PROJECT_DESC.md
 
 .scannerwork
 .specstory
+
+# exclude saved browser profiles
+profiles/

--- a/examples/testing/cli/tasks/9_todolist_deletion/task_9_todolist_deletion.toml
+++ b/examples/testing/cli/tasks/9_todolist_deletion/task_9_todolist_deletion.toml
@@ -3,7 +3,7 @@ name = "9_todolist_deletion"  # REQUIRED: Unique name for the task
 start_url = "https://freetodolist.com"  # REQUIRED: URL where the browser session should start
 description = "Login to FreeTodoList platform and delete the specified item from the TODO list"
 extra_instructions = [
-    "Login using the provided credentials",
+    "Note: Browser session is reused from the creation task, so you should already be logged in",
     "Navigate to the 'TODOs' list that was created in the previous task",
     "Find and open the specific item that was provided as SELECTED_ITEM",
     "Delete that selected item from the TODO list",
@@ -11,7 +11,7 @@ extra_instructions = [
     "After deleting the item, delete the parent list as well",
 ]
 allowed_domains = ["freetodolist.com", "www.freetodolist.com"]
-dependencies = ["9_todolist_creation"]
+dependencies = ["9_todolist_creation:reuse_session"]  # Reuse browser session to maintain login state
 
 [secrets]
 EMAIL_CREDENTIAL = "cekijit723@ampdial.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bugninja"
-version = "0.1.7"
+version = "0.1.8"
 description = "AI-Powered Browser Automation"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ memory = [
 
 [[package]]
 name = "bugninja"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
## Goals / Problems

- Allow dependent testcases to reuse the browser session of a previous testcase.
- Avoid repeated authentication, duplicated setup steps, and unnecessary performance overhead.
- Improve clarity and control over dependency behavior.

## Solution

- Extended dependency syntax to support session reuse by adding the `:reuse_session` modifier.
- Updated task execution to reuse browser state (cookies, sessions, login context) when this modifier is present.
- Maintained compatibility with the original dependency format.

**Old format:**

```python
dependencies = ["9_todolist_creation"]
```

**New format:**

```python
dependencies = ["9_todolist_creation:reuse_session"]
```

## Features

- Ability to reuse the browser session of another testcase
- More explicit dependency definitions through the `:reuse_session` suffix.

## Other Changes

- Adjustments to dependency parsing logic.
- Minimal documentation updates.

## Tests TODO

- [ ] Try to run testcase  `9_todolist_deletion` and validate that
    - [ ] The dependency between the two testcases is detected and valid
    - [ ] First the list creation endpoint runs
    - [ ] When the deletion testcase navigates to the webpage, the login credentials are still valid!


